### PR TITLE
verious cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ exclude = [
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
+thiserror = "1.0"
 semver = "0.10"
 xpath_reader = "0.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,19 @@
-use failure::SyncFailure;
+use semver::SemVerError;
+use std::io;
+use thiserror::Error;
 use xpath_reader::Error as XPathError;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[fail(display = "info.xml missing")]
+    #[error("info.xml missing")]
     InfoXmlMissing,
-    #[fail(display = "XML error: {:?}", err)]
-    Xml { err: SyncFailure<XPathError> },
+    #[error("failed to read info.xml")]
+    IO(#[from] io::Error),
+    #[error("XML error: {err}")]
+    Xml {
+        #[from]
+        err: XPathError,
+    },
+    #[error("malformed version number")]
+    SemVer(#[from] SemVerError),
 }


### PR DESCRIPTION
- use `std::error::Error` instead of failure
  - failure doesn't integrate well with `std` and has been depricated
- use `std::fs::read_to_string`
- replace `&String` arguments with `&str`